### PR TITLE
[CB-10818] Support the scroll deceleration speed preference.

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -169,6 +169,16 @@
             }
         }
     }
+
+    NSString* decelerationSetting = [settings cordovaSettingForKey:@"WKWebViewDecelerationSpeed"];
+    if (!decelerationSetting) {
+        // Fallback to the UIWebView-named preference
+        decelerationSetting = [settings cordovaSettingForKey:@"UIWebViewDecelerationSpeed"];
+    }
+
+    if (![@"fast" isEqualToString:decelerationSetting]) {
+        [wkWebView.scrollView setDecelerationRate:UIScrollViewDecelerationRateNormal];
+    }
 }
 
 - (void)updateWithInfo:(NSDictionary*)info


### PR DESCRIPTION
Adds a new preference `WKWebViewDecelerationSpeed`, but will safely fall back to the `UIWebViewDecelerationSpeed` for existing projects.

It might be preferable to always use `UIWebViewDecelerationSpeed` rather than adding a new preference, although the name would be inconsistent.