### PR TITLE
CB-10817 The webView should reload when a crash occurs

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -280,6 +280,11 @@
     }
 }
 
+- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView
+{
+    [webView reload];
+}
+
 - (BOOL)defaultResourcePolicyForURL:(NSURL*)url
 {
     // all file:// urls are allowed


### PR DESCRIPTION
With the iOS9 API, it is now possible to detect when the WKProcess dies. See the API details for reference:
https://developer.apple.com/library/ios/releasenotes/General/iOS90APIDiffs/Objective-C/WebKit.html

When it does, the content is blanked out and the URL becomes nil. This results in a "white screen" that can only be resolved by restarting the app. See this for more info: https://bugs.webkit.org/show_bug.cgi?id=148685

I've Implemented the method: `- (void)webViewWebContentProcessDidTerminate:(WKWebView *)webView` which will be called when the process dies and reload the webView.