### PR TITLE
CB-9888: (iOS) check & reload WKWebView

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -103,13 +103,16 @@
 
 - (BOOL)reloadIfRequired
 {
-    NSLog(@"%@", @"CDVWKWebViewEngine reloadIfRequired");
     WKWebView* wkWebView = (WKWebView*)_engineWebView;
     NSString* title = wkWebView.title;
-    NSLog(@"CDVWKWebViewEngine reloadIfRequired WKWebView.title: %@", title);
-
     BOOL reload = ((title == nil) || [title isEqualToString:@""]);
+
+#ifdef DEBUG
+    NSLog(@"%@", @"CDVWKWebViewEngine reloadIfRequired");
+    NSLog(@"CDVWKWebViewEngine reloadIfRequired WKWebView.title: %@", title);
     NSLog(@"CDVWKWebViewEngine reloadIfRequired reload: %u", reload);
+#endif
+
     if (reload) {
         NSLog(@"%@", @"CDVWKWebViewEngine reloading!");
         [wkWebView reload];


### PR DESCRIPTION
PR as discussed on JIRA @shazron 

### Platforms affected

iOS 9

### What does this PR do?

Checks whether the WKWebView content process has died when the app enters
the foreground. If it has, then reloads the WKWebView

### What testing has been done on this change?

Tested on iOS9.3 emulator and iPhone 6 / 9.3.1

### Checklist
- [x] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.

When an app is entering the foreground,
the WKWebView content process sometimes dies without
calling the webViewContentProcessDidTerminate delegate function.

This PR checks whether the content process has died, by
examining the title property of the WKWebView, which is nil
when the process has died.

If the process has died the WKWebView is reloaded,
which avoids the White Screen Of Death problem described
in CB-9888.