### PR TITLE
CB-10142, CB-10732: Allow opening WebSQL databases in WKWebView

### DIFF
--- a/src/ios/CDVWKWebViewUIDelegate.m
+++ b/src/ios/CDVWKWebViewUIDelegate.m
@@ -120,4 +120,15 @@
     [rootController presentViewController:alert animated:YES completion:nil];
 }
 
+- (void)                        _webView:(WKWebView *)webView
+    decideDatabaseQuotaForSecurityOrigin:(WKSecurityOrigin *)securityOrigin
+                            currentQuota:(unsigned long long)currentQuota
+                      currentOriginUsage:(unsigned long long)currentOriginUsage
+                    currentDatabaseUsage:(unsigned long long)currentUsage
+                           expectedUsage:(unsigned long long)expectedUsage
+                         decisionHandler:(void (^)(unsigned long long newQuota))decisionHandler {
+    decisionHandler(1024*1024*50); //default to 50MB
+}
+
+
 @end


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

iOS

### What does this PR do?

Allows WebSql databases to be opened when using this plugin. Right now it gives databases a quota of 50MB.

### What testing has been done on this change?

Tested on iOS 9 iPhone simulator and iPad. 

### Checklist
- [X] [ICLA](http://www.apache.org/licenses/icla.txt) has been signed and submitted to secretary@apache.org.
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

