### PR TITLE
CB-11074 - Ensure settings from config.xml are taken into consideration

### DIFF
--- a/tests/ios/CDVWKWebViewEngineTest/CDVWKWebViewEngineLibTests/CDVWKWebViewEngineTest.m
+++ b/tests/ios/CDVWKWebViewEngineTest/CDVWKWebViewEngineLibTests/CDVWKWebViewEngineTest.m
@@ -21,6 +21,7 @@
 #import <XCTest/XCTest.h>
 #import "CDVWKWebViewEngine.h"
 #import <Cordova/NSDictionary+CordovaPreferences.h>
+#import <Cordova/CDVAvailability.h>
 
 @interface CDVWKWebViewEngineTest : XCTestCase
 
@@ -35,12 +36,20 @@
 
 @end
 
+@interface CDVViewController ()
+
+// expose property as readwrite, for test purposes
+@property (nonatomic, readwrite, strong) NSMutableDictionary* settings;
+
+@end
+
 @implementation CDVWKWebViewEngineTest
 
 - (void)setUp {
     [super setUp];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     
+    // NOTE: no app settings are set, so it will rely on default WKWebViewConfiguration settings
     self.plugin = [[CDVWKWebViewEngine alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
     self.viewController = [[CDVViewController alloc] init];
     [self.viewController registerPlugin:self.plugin withClassName:NSStringFromClass([self.plugin class])];
@@ -77,10 +86,13 @@
     id<CDVWebViewEngineProtocol> webViewEngineProtocol = self.plugin;
     WKWebView* wkWebView = (WKWebView*)self.plugin.engineWebView;
     
+    // iOS >=10 defaults to NO, < 10 defaults to YES.
+    BOOL mediaPlaybackRequiresUserActionDefault = IsAtLeastiOSVersion(@"10.0")? NO : YES;
+    
     NSDictionary* preferences = @{
                                [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
                                [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
-                               [@"MediaPlaybackRequiresUserAction" lowercaseString] : @NO, // default is YES
+                               [@"MediaPlaybackRequiresUserAction" lowercaseString] : @(!mediaPlaybackRequiresUserActionDefault), // default is NO on iOS >= 10, YES for < 10
                                [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
                                [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
                                [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
@@ -95,8 +107,12 @@
     XCTAssertEqualWithAccuracy(wkWebView.configuration.preferences.minimumFontSize, 1.1, 0.0001);
     
     // the WKWebViewConfiguration properties, we **cannot** change outside of initialization
+    if (IsAtLeastiOSVersion(@"10.0")) {
+        XCTAssertFalse(wkWebView.configuration.mediaPlaybackRequiresUserAction);
+    } else {
+        XCTAssertTrue(wkWebView.configuration.mediaPlaybackRequiresUserAction);
+    }
     XCTAssertFalse(wkWebView.configuration.allowsInlineMediaPlayback);
-    XCTAssertTrue(wkWebView.configuration.mediaPlaybackRequiresUserAction);
     XCTAssertFalse(wkWebView.configuration.suppressesIncrementalRendering);
     XCTAssertTrue(wkWebView.configuration.mediaPlaybackAllowsAirPlay);
     
@@ -112,6 +128,73 @@
     }
     
     XCTAssertTrue(wkWebView.scrollView.decelerationRate == UIScrollViewDecelerationRateFast);
+}
+
+- (void) testConfigurationFromSettings {
+    // we need to re-set the plugin from the "setup" to take in the app settings we need
+    self.plugin = [[CDVWKWebViewEngine alloc] initWithFrame:CGRectMake(0, 0, 100, 100)];
+    self.viewController = [[CDVViewController alloc] init];
+    
+    // generate the app settings
+    // iOS >=10 defaults to NO, < 10 defaults to YES.
+    BOOL mediaPlaybackRequiresUserActionDefault = IsAtLeastiOSVersion(@"10.0")? NO : YES;
+
+    NSDictionary* settings = @{
+                                  [@"MinimumFontSize" lowercaseString] : @1.1, // default is 0.0
+                                  [@"AllowInlineMediaPlayback" lowercaseString] : @YES, // default is NO
+                                  [@"MediaPlaybackRequiresUserAction" lowercaseString] : @(!mediaPlaybackRequiresUserActionDefault), // default is NO on iOS >= 10, YES for < 10
+                                  [@"SuppressesIncrementalRendering" lowercaseString] : @YES, // default is NO
+                                  [@"MediaPlaybackAllowsAirPlay" lowercaseString] : @NO, // default is YES
+                                  [@"DisallowOverscroll" lowercaseString] : @YES, // so bounces is to be NO. defaults to NO
+                                  [@"WKWebViewDecelerationSpeed" lowercaseString] : @"fast" // default is 'normal'
+                                  };
+    // this can be set because of the Category at the top of the file
+    self.viewController.settings = [settings mutableCopy];
+    
+    // app settings are read after you register the plugin
+    [self.viewController registerPlugin:self.plugin withClassName:NSStringFromClass([self.plugin class])];
+    XCTAssert([self.plugin conformsToProtocol:@protocol(CDVWebViewEngineProtocol)], @"Plugin does not conform to CDVWebViewEngineProtocol");
+    
+    // after registering (thus plugin initialization), we can grab the webview configuration
+    WKWebView* wkWebView = (WKWebView*)self.plugin.engineWebView;
+    
+    // the only preference we can set, we **can** change this during runtime
+    XCTAssertEqualWithAccuracy(wkWebView.configuration.preferences.minimumFontSize, 1.1, 0.0001);
+    
+    // the WKWebViewConfiguration properties, we **cannot** change outside of initialization
+    if (IsAtLeastiOSVersion(@"10.0")) {
+        XCTAssertTrue(wkWebView.configuration.mediaPlaybackRequiresUserAction);
+    } else {
+        XCTAssertFalse(wkWebView.configuration.mediaPlaybackRequiresUserAction);
+    }
+    XCTAssertTrue(wkWebView.configuration.allowsInlineMediaPlayback);
+    XCTAssertTrue(wkWebView.configuration.suppressesIncrementalRendering);
+    // The test case below is in a separate test "testConfigurationWithMediaPlaybackAllowsAirPlay" (Apple bug) 
+    // XCTAssertFalse(wkWebView.configuration.mediaPlaybackAllowsAirPlay);
+    
+    // in the test above, DisallowOverscroll is YES, so no bounce
+    if ([wkWebView respondsToSelector:@selector(scrollView)]) {
+        XCTAssertFalse(((UIScrollView*)[wkWebView scrollView]).bounces);
+    } else {
+        for (id subview in wkWebView.subviews) {
+            if ([[subview class] isSubclassOfClass:[UIScrollView class]]) {
+                XCTAssertFalse(((UIScrollView*)subview).bounces = NO);
+            }
+        }
+    }
+    
+    XCTAssertTrue(wkWebView.scrollView.decelerationRate == UIScrollViewDecelerationRateFast);
+}
+
+- (void) testConfigurationWithMediaPlaybackAllowsAirPlay {
+    WKWebViewConfiguration* configuration = [WKWebViewConfiguration new];
+    configuration.allowsAirPlayForMediaPlayback = NO;
+    
+    WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:CGRectMake(0, 0, 100, 100) configuration:configuration];
+    
+    XCTAssertFalse(configuration.allowsAirPlayForMediaPlayback);
+    // Uh-oh, bug in WKWebView below. Tested on iOS 9, iOS 10 beta 3
+    XCTAssertFalse(wkWebView.configuration.allowsAirPlayForMediaPlayback);    
 }
 
 @end

--- a/tests/ios/CDVWKWebViewEngineTest/CDVWKWebViewEngineTest.xcodeproj/xcshareddata/xcschemes/CDVWKWebViewEngineLibTests.xcscheme
+++ b/tests/ios/CDVWKWebViewEngineTest/CDVWKWebViewEngineTest.xcodeproj/xcshareddata/xcschemes/CDVWKWebViewEngineLibTests.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -37,6 +37,11 @@
                BlueprintName = "CDVWKWebViewEngineLibTests"
                ReferencedContainer = "container:CDVWKWebViewEngineTest.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CDVWKWebViewEngineTest/testConfigurationWithMediaPlaybackAllowsAirPlay">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
       <MacroExpansion>
@@ -48,15 +53,18 @@
             ReferencedContainer = "container:CDVWKWebViewEngineTest.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -71,10 +79,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference


### PR DESCRIPTION
Take note of the disabled `testConfigurationWithMediaPlaybackAllowsAirPlay` unit test which demonstrates that the allowsAirPlayForMediaPlayback is not sticky (apparent Apple bug).

Also, `mediaPlaybackRequiresUserAction` configuration default differs on iOS 10 versus earlier versions (on iOS 10 it defaults to NO, when it was YES, previously). Probably due to: https://webkit.org/blog/6784/new-video-policies-for-ios/ 

This preserves `updateWithInfo` which is needed to update other settings, which was deleted in the other two pull requests.