### PR TITLE
CB-10228:(iOS) AppendUserAgent not working with WKWebView

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -99,7 +99,7 @@
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;
 
-    if ([self.viewController isKindOfClass:[CDVViewController class]]) {
+    if (IsAtLeastiOSVersion(@"9.0") && [self.viewController isKindOfClass:[CDVViewController class]]) {
         wkWebView.customUserAgent = ((CDVViewController*) self.viewController).userAgent;
     }
 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -99,6 +99,10 @@
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;
 
+    if ([self.viewController isKindOfClass:[CDVViewController class]]) {
+        wkWebView.customUserAgent = ((CDVViewController*) self.viewController).userAgent;
+    }
+
     if ([self.viewController conformsToProtocol:@protocol(WKUIDelegate)]) {
         wkWebView.UIDelegate = (id <WKUIDelegate>)self.viewController;
     }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS: Currently the wkWebview uses the default user agent, ignoring Cordova's OverrideUserAgent and AppendUserAgent in config.xml

### What does this PR do?
This attempts to set the customUserAgent property of the wkWebview to what is already computed in the CDVViewController

### What testing has been done on this change?
Npm tests have been run.  User agents verified changed on Cordova iOS 4.3.0 and Cordova 6.4.0.

### Checklist
- [ X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
