### PR TITLE
CB-12317: Allow to configure navigation by gestures

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ WKWebView may not fully launch (the deviceready event may not fire) unless if th
 
 #### config.xml
 
-        <feature name="CDVWKWebViewEngine">
-            <param name="ios-package" value="CDVWKWebViewEngine" />
-        </feature>
+```xml
+<feature name="CDVWKWebViewEngine">
+  <param name="ios-package" value="CDVWKWebViewEngine" />
+</feature>
 
-        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
-
+<preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
+```
 
 Notes
 ------
@@ -76,6 +77,15 @@ Application Transport Security (ATS) in iOS 9
 Starting with [cordova-cli 5.4.0](https://www.npmjs.com/package/cordova), it will support automatic conversion of the [&lt;access&gt;](http://cordova.apache.org/docs/en/edge/guide/appdev/whitelist/index.html) tags in config.xml to Application Transport Security [ATS](https://developer.apple.com/library/prerelease/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) directives. 
 
 Upgrade to at least version 5.4.0 of the cordova-cli to use this new functionality.
+
+Enabling Navigation Gestures ("Swipe Navigation")
+-----------
+
+In order to allow swiping backwards and forwards in browser history like Safari does, you can set the following preference in your `config.xml`:
+
+```xml
+<preference name="AllowBackForwardNavigationGestures" value="true" />
+```
 
 Limitations
 --------

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -274,6 +274,8 @@ static void * KVOContext = &KVOContext;
     } else {
         [wkWebView.scrollView setDecelerationRate:UIScrollViewDecelerationRateFast];
     }
+
+    wkWebView.allowsBackForwardNavigationGestures = [settings cordovaBoolSettingForKey:@"AllowBackForwardNavigationGestures" defaultValue:NO];
 }
 
 - (void)updateWithInfo:(NSDictionary*)info


### PR DESCRIPTION
### Platforms affected
All iOS devices supporting the WKWebView.

### What does this PR do?
This PR adds a new configuration option `AllowBackForwardNavigationGestures`, which is disabled by default. You can enable it in your `config.xml` via:

```xml
<preference name="AllowBackForwardNavigationGestures" value="true" />
```

Afterwards, the navigation gestures for forward/backward are enabled in the WebView (aka "Swipe Navigation").

### What testing has been done on this change?
* I tested it without this preference set => swipe navigation disabled like before (backwards compatability)
* I tested it with the preference set to `true` like above => swipe navigation enabled. You can swipe back and forward like in Safari.
