### PR TITLE
Allow XHR to file:// and allow local file (upload) handling

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -76,6 +76,17 @@
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
     configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
 
+    // allow access to file api
+    @try {
+      [configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+    }
+    @catch (NSException *exception) {}
+
+    @try {
+      [configuration setValue:@TRUE forKey:@"allowUniversalAccessFromFileURLs"];
+    }
+    @catch (NSException *exception) {}
+
     return configuration;
 }
 


### PR DESCRIPTION
Until there is a better solution to setting this property, this solves the XHR and local file api issues.
This issue is described further in https://bugs.webkit.org/show_bug.cgi?id=154916.

### Platforms affected
- [x] iOS

### What does this PR do?
- [x] Prevents "Security DOM 18 error" while manipulating files, such as handling file uploads
- [x] Prevents "NetworkError (DOM Exception 19):  A network error occurred." while loading files through XHR from `file://`

### What testing has been done on this change?
- [x] XHR and file handling

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
