### PR TITLE
Allow XHR to file:// and allow local file (upload) handling

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -76,6 +76,17 @@
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
     configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
 
+    // allow access to file api
+    @try {
+      [configuration.preferences setValue:@TRUE forKey:@"allowFileAccessFromFileURLs"];
+    }
+    @catch (NSException *exception) {}
+
+    @try {
+      [configuration setValue:@TRUE forKey:@"allowUniversalAccessFromFileURLs"];
+    }
+    @catch (NSException *exception) {}
+
     return configuration;
 }
 
@@ -172,16 +183,16 @@ static void * KVOContext = &KVOContext;
 {
     BOOL title_is_nil = (title == nil);
     BOOL location_is_blank = [[location absoluteString] isEqualToString:@"about:blank"];
-    
+
     BOOL reload = (title_is_nil || location_is_blank);
-    
+
 #ifdef DEBUG
     NSLog(@"%@", @"CDVWKWebViewEngine shouldReloadWebView::");
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView title: %@", title);
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView location: %@", [location absoluteString]);
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView reload: %u", reload);
 #endif
-    
+
     return reload;
 }
 


### PR DESCRIPTION
I know this PR won't be merged but I wanted to submit it anyways for people who face the same issues and want a solution that works for at least iOS 9 + 10.

(This PR replaces an earlier experimental version at https://github.com/apache/cordova-plugin-wkwebview-engine/pull/26)

Until there is a better solution to setting this property, this solves the XHR and local file api issues.
This issue is described further in https://bugs.webkit.org/show_bug.cgi?id=154916.

### Platforms affected
- [x] iOS

### What does this PR do?
- [x] Prevents "Security DOM 18 error" while manipulating files, such as handling file uploads
- [x] Prevents "NetworkError (DOM Exception 19):  A network error occurred." while loading files through XHR from `file://`

### What testing has been done on this change?
- [x] XHR and file handling (incl. reading using File api etc)
- [x] Test on iOS 10
- [x] Test on iOS 9