### PR TITLE
CB-12497 - location.href links are silently disallowed

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -428,7 +428,12 @@ static void * KVOContext = &KVOContext;
         SEL selector = NSSelectorFromString(@"shouldOverrideLoadWithRequest:navigationType:");
         if ([plugin respondsToSelector:selector]) {
             anyPluginsResponded = YES;
-            shouldAllowRequest = (((BOOL (*)(id, SEL, id, int))objc_msgSend)(plugin, selector, navigationAction.request, navigationAction.navigationType));
+            // https://issues.apache.org/jira/browse/CB-12497
+            int navType = (int)navigationAction.navigationType;
+            if (WKNavigationTypeOther == navigationAction.navigationType) {
+                navType = (int)UIWebViewNavigationTypeOther;
+            }
+            shouldAllowRequest = (((BOOL (*)(id, SEL, id, int))objc_msgSend)(plugin, selector, navigationAction.request, navType));
             if (!shouldAllowRequest) {
                 break;
             }


### PR DESCRIPTION
### Platforms affected

iOS WKWebView

### What does this PR do?

Fixes the bug where javascript navigations were silently disallowed on this plugin.

### What testing has been done on this change?

Manual testing on device - using a new default project with this plugin, and `<button onclick="location.href='tel:15551234'">LOCATION.HREF</button>`

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
