### PR TITLE
CB-10376, CB-12037: (ios) Fix bug where WKWebView doesnt respect the KeyboardDisplayRequiresUserAction setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ In order to allow swiping backwards and forwards in browser history like Safari 
 <preference name="AllowBackForwardNavigationGestures" value="true" />
 ```
 
+You can also set this preference dynamically from JavaScript:
+
+```js
+window.WkWebView.allowsBackForwardNavigationGestures(true)
+window.WkWebView.allowsBackForwardNavigationGestures(false)
+```
+
 Limitations
 --------
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Cordova WKWebView Engine FORK
+
+This fork has two new features.
+
+1. It honors the `<preference name="KeyboardDisplayRequiresUserAction" value="false" />` preference.
+
+2. You can dynamically set `window.WkWebKit.allowsBackForwardNavigationGestures(true or false)`.
+
+---
+
 <!--
 # license: Licensed to the Apache Software Foundation (ASF) under one
 #         or more contributor license agreements.  See the NOTICE file

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,6 +41,10 @@
             <clobbers target="cordova.exec" />
         </js-module>
 
+        <js-module src="src/www/ios/ios-wkwebview.js" name="ios-wkwebview">
+            <clobbers target="window.WkWebView" />
+        </js-module>
+
         <config-file target="config.xml" parent="/*">
             <feature name="CDVWKWebViewEngine">
                 <param name="ios-package" value="CDVWKWebViewEngine" />

--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -24,4 +24,6 @@
 
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 
+- (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -474,6 +474,19 @@ static void * KVOContext = &KVOContext;
     return decisionHandler(NO);
 }
 
+#pragma mark - Plugin interface
+
+- (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
+{
+  id value = [command.arguments objectAtIndex:0];
+  if (!([value isKindOfClass:[NSNumber class]])) {
+    value = [NSNumber numberWithBool:NO];
+  }
+
+  WKWebView* wkWebView = (WKWebView*)_engineWebView;
+  wkWebView.allowsBackForwardNavigationGestures = [value boolValue];
+}
+
 @end
 
 #pragma mark - CDVWKWeakScriptMessageHandler

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -120,7 +120,7 @@
     }
 
     if (![settings cordovaBoolSettingForKey:@"KeyboardDisplayRequiresUserAction" defaultValue:YES]) {
-      	[self keyboardDisplayDoesNotRequireUserAction];
+        [self keyboardDisplayDoesNotRequireUserAction];
     }
 
     [self updateSettings:settings];
@@ -139,14 +139,14 @@
 
 // https://github.com/Telerik-Verified-Plugins/WKWebView/commit/04e8296adeb61f289f9c698045c19b62d080c7e3
 - (void) keyboardDisplayDoesNotRequireUserAction {
-		SEL sel = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
-  	Class WKContentView = NSClassFromString(@"WKContentView");
-  	Method method = class_getInstanceMethod(WKContentView, sel);
-  	IMP originalImp = method_getImplementation(method);
-  	IMP imp = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
-    		((void (*)(id, SEL, void*, BOOL, BOOL, id))originalImp)(me, sel, arg0, TRUE, arg2, arg3);
-  	});
-  	method_setImplementation(method, imp);
+    SEL sel = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
+    Class WKContentView = NSClassFromString(@"WKContentView");
+    Method method = class_getInstanceMethod(WKContentView, sel);
+    IMP originalImp = method_getImplementation(method);
+    IMP imp = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
+        ((void (*)(id, SEL, void*, BOOL, BOOL, id))originalImp)(me, sel, arg0, TRUE, arg2, arg3);
+    });
+    method_setImplementation(method, imp);
 }
 
 - (void)onReset {

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -17,6 +17,7 @@
  under the License.
  */
 
+#import <objc/runtime.h>
 #import "CDVWKWebViewEngine.h"
 #import "CDVWKWebViewUIDelegate.h"
 #import "CDVWKProcessPoolFactory.h"
@@ -118,6 +119,10 @@
         [wkWebView.configuration.userContentController addScriptMessageHandler:(id < WKScriptMessageHandler >)self.viewController name:CDV_BRIDGE_NAME];
     }
 
+    if (![settings cordovaBoolSettingForKey:@"KeyboardDisplayRequiresUserAction" defaultValue:YES]) {
+      	[self keyboardDisplayDoesNotRequireUserAction];
+    }
+
     [self updateSettings:settings];
 
     // check if content thread has died on resume
@@ -130,6 +135,18 @@
     NSLog(@"Using WKWebView");
 
     [self addURLObserver];
+}
+
+// https://github.com/Telerik-Verified-Plugins/WKWebView/commit/04e8296adeb61f289f9c698045c19b62d080c7e3
+- (void) keyboardDisplayDoesNotRequireUserAction {
+		SEL sel = sel_getUid("_startAssistingNode:userIsInteracting:blurPreviousNode:userObject:");
+  	Class WKContentView = NSClassFromString(@"WKContentView");
+  	Method method = class_getInstanceMethod(WKContentView, sel);
+  	IMP originalImp = method_getImplementation(method);
+  	IMP imp = imp_implementationWithBlock(^void(id me, void* arg0, BOOL arg1, BOOL arg2, id arg3) {
+    		((void (*)(id, SEL, void*, BOOL, BOOL, id))originalImp)(me, sel, arg0, TRUE, arg2, arg3);
+  	});
+  	method_setImplementation(method, imp);
 }
 
 - (void)onReset {

--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -175,3 +175,9 @@ if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandl
       module.exports = execProxy;
    });
 }
+
+window.WkWebKit = {
+  allowsBackForwardNavigationGestures: function(allow) {
+    exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
+  }
+}

--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -175,9 +175,3 @@ if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandl
       module.exports = execProxy;
    });
 }
-
-window.WkWebKit = {
-  allowsBackForwardNavigationGestures: function(allow) {
-    exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
-  }
-}

--- a/src/www/ios/ios-wkwebview.js
+++ b/src/www/ios/ios-wkwebview.js
@@ -1,0 +1,9 @@
+var exec = require('cordova/exec');
+
+const WkWebKit = {
+  allowsBackForwardNavigationGestures: function(allow) {
+    exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
+  }
+}
+
+module.exports = WkWebKit


### PR DESCRIPTION
### Platforms affected

- iOS

### What does this PR do?

This PR does some magic to allow `.focus()` to bring up the keyboard in WKWebView. I read about this approach in a few places and saw [this commit](https://github.com/Telerik-Verified-Plugins/WKWebView/commit/04e8296adeb61f289f9c698045c19b62d080c7e3) in another plugin. From what I understand, its basically accessing a private method in WKWebView.

### What testing has been done on this change?

Using it on my iPhone 7 and in the Simulator and it definitely works :) I'm not a native developer so I could use some guidance getting this PR to the point where its mergeable. But its definitely useful and absolutely necessary for [the app I'm building](www.notion.so).

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
