### PR TITLE
CB-13205: Dynamic swipe back enabled preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 Cordova WKWebView Engine
 ======
 
-This plugin makes `Cordova` use the `WKWebView` component instead of the default `UIWebView` component, and is installable only on a system with the iOS 9.0 SDK. 
+This plugin makes `Cordova` use the `WKWebView` component instead of the default `UIWebView` component, and is installable only on a system with the iOS 9.0 SDK.
 
 In iOS 9, Apple has fixed the [issue](http://www.openradar.me/18039024) present through iOS 8 where you cannot load locale files using file://, and must resort to using a local webserver. **However, you are still not able to use XHR from the file:// protocol without [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) enabled on your server.**
 
@@ -76,7 +76,7 @@ We have an [experimental plugin](https://github.com/apache/cordova-plugins/tree/
 Application Transport Security (ATS) in iOS 9
 -----------
 
-Starting with [cordova-cli 5.4.0](https://www.npmjs.com/package/cordova), it will support automatic conversion of the [&lt;access&gt;](http://cordova.apache.org/docs/en/edge/guide/appdev/whitelist/index.html) tags in config.xml to Application Transport Security [ATS](https://developer.apple.com/library/prerelease/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) directives. 
+Starting with [cordova-cli 5.4.0](https://www.npmjs.com/package/cordova), it will support automatic conversion of the [&lt;access&gt;](http://cordova.apache.org/docs/en/edge/guide/appdev/whitelist/index.html) tags in config.xml to Application Transport Security [ATS](https://developer.apple.com/library/prerelease/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) directives.
 
 Upgrade to at least version 5.4.0 of the cordova-cli to use this new functionality.
 
@@ -89,6 +89,13 @@ In order to allow swiping backwards and forwards in browser history like Safari 
 <preference name="AllowBackForwardNavigationGestures" value="true" />
 ```
 
+You can also set this preference dynamically from JavaScript:
+
+```js
+window.WkWebView.allowsBackForwardNavigationGestures(true)
+window.WkWebView.allowsBackForwardNavigationGestures(false)
+```
+
 Limitations
 --------
 
@@ -97,7 +104,7 @@ If you are upgrading from UIWebView, please note the limitations of using WKWebV
 Apple Issues
 -------
 
-The `AllowInlineMediaPlayback` preference will not work because of this [Apple bug](http://openradar.appspot.com/radar?id=6673091526656000). This bug [has been fixed](https://issues.apache.org/jira/browse/CB-11452) in [iOS 10](https://twitter.com/shazron/status/745546355796389889). 
+The `AllowInlineMediaPlayback` preference will not work because of this [Apple bug](http://openradar.appspot.com/radar?id=6673091526656000). This bug [has been fixed](https://issues.apache.org/jira/browse/CB-11452) in [iOS 10](https://twitter.com/shazron/status/745546355796389889).
 
 
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -41,6 +41,10 @@
             <clobbers target="cordova.exec" />
         </js-module>
 
+        <js-module src="src/www/ios/ios-wkwebview.js" name="ios-wkwebview">
+            <clobbers target="window.WkWebView" />
+        </js-module>
+
         <config-file target="config.xml" parent="/*">
             <feature name="CDVWKWebViewEngine">
                 <param name="ios-package" value="CDVWKWebViewEngine" />

--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -24,4 +24,6 @@
 
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
 
+- (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
+
 @end

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -461,7 +461,7 @@ static void * KVOContext = &KVOContext;
 
 - (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
 {
-    id value = [command.arguments objectAtIndex:0];
+    id value = [command argumentAtIndex:0];
     if (!([value isKindOfClass:[NSNumber class]])) {
         value = [NSNumber numberWithBool:NO];
     }

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -173,16 +173,16 @@ static void * KVOContext = &KVOContext;
 {
     BOOL title_is_nil = (title == nil);
     BOOL location_is_blank = [[location absoluteString] isEqualToString:@"about:blank"];
-    
+
     BOOL reload = (title_is_nil || location_is_blank);
-    
+
 #ifdef DEBUG
     NSLog(@"%@", @"CDVWKWebViewEngine shouldReloadWebView::");
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView title: %@", title);
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView location: %@", [location absoluteString]);
     NSLog(@"CDVWKWebViewEngine shouldReloadWebView reload: %u", reload);
 #endif
-    
+
     return reload;
 }
 
@@ -455,6 +455,19 @@ static void * KVOContext = &KVOContext;
     }
 
     return decisionHandler(NO);
+}
+
+#pragma mark - Plugin interface
+
+- (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
+{
+    id value = [command.arguments objectAtIndex:0];
+    if (!([value isKindOfClass:[NSNumber class]])) {
+        value = [NSNumber numberWithBool:NO];
+    }
+
+    WKWebView* wkWebView = (WKWebView*)_engineWebView;
+    wkWebView.allowsBackForwardNavigationGestures = [value boolValue];
 }
 
 @end

--- a/src/www/ios/ios-wkwebview.js
+++ b/src/www/ios/ios-wkwebview.js
@@ -1,6 +1,6 @@
 var exec = require('cordova/exec');
 
-const WkWebKit = {
+var WkWebKit = {
     allowsBackForwardNavigationGestures: function(allow) {
         exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
     }

--- a/src/www/ios/ios-wkwebview.js
+++ b/src/www/ios/ios-wkwebview.js
@@ -1,0 +1,9 @@
+var exec = require('cordova/exec');
+
+const WkWebKit = {
+    allowsBackForwardNavigationGestures: function(allow) {
+        exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
+    }
+}
+
+module.exports = WkWebKit

--- a/src/www/ios/ios-wkwebview.js
+++ b/src/www/ios/ios-wkwebview.js
@@ -1,9 +1,9 @@
 var exec = require('cordova/exec');
 
 var WkWebKit = {
-    allowsBackForwardNavigationGestures: function(allow) {
-        exec(null, null, "CDVWKWebViewEngine", "allowsBackForwardNavigationGestures", [allow]);
+    allowsBackForwardNavigationGestures: function (allow) {
+        exec(null, null, 'CDVWKWebViewEngine', 'allowsBackForwardNavigationGestures', [allow]);
     }
-}
+};
 
-module.exports = WkWebKit
+module.exports = WkWebKit;


### PR DESCRIPTION
### Platforms affected

iOS

### What does this PR do?

Creates a browser api to dynamically change the `allowsBackForwardNavigationGestures` preference.

### What testing has been done on this change?

This is being used by 500 Beta testers at www.notion.so

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

I'm not sure how to create a test for this. If its necessary, can I please get some help?