### PR TITLE
CB-13987: (ios) Fix WKWebView doesn't layout properly at launch on iP…

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -97,6 +97,13 @@
 
     // re-create WKWebView, since we need to update configuration
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.engineWebView.frame configuration:configuration];
+
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
+    if (@available(iOS 11.0, *)) {
+        [wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    }
+#endif
+    
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;
 


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fixes the issue  [CB-13987](https://issues.apache.org/jira/browse/CB-13987). The WKWebView shows in iPhone X using fullscreen from the start.

### What testing has been done on this change?
Tested in own project using iPhone X simulator.

I extracted the fix by investigating at the code of the ionic extension 
https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/master/src/ios/CDVWKWebViewEngine.m#L229

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
