### PR TITLE
add cordova-ios in plugin keyword for npm ios plugin searching

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "keywords": [
     "cordova",
-    "wkwebview"
+    "wkwebview",
+    "cordova-ios"
   ],
   "scripts": {
     "test": "npm run eslint && npm run objc-tests",


### PR DESCRIPTION

### Platforms affected
iOS

### What does this PR do?
Add cordova-ios in the plugin keyword list, so the plugin can be find when searching for ios specific cordova plugins

### What testing has been done on this change?
NA