### PR TITLE
CB-12815: (ios) Fix bug nativeCallback not executed when app is in background

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-wkwebview-engine",
-  "version": "1.1.5-dev",
+  "version": "1.2.0-dev",
   "description": "The official Apache Cordova WKWebView Engine Plugin",
   "main": "index.js",
   "repository": {

--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,7 +124,7 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    Promise.resolve(cordova.callbackFromNative(callbackId, success, status, args, keepCallback));
+    Promise.resolve(cordova.callbackFromNative(callbackId, success, status, args, keepCallback)); // eslint-disable-line
 };
 
 // for backwards compatibility

--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,9 +124,7 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    setTimeout(function () {
-    	cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
-    }, 0);
+    Promise.resolve(cordova.callbackFromNative(callbackId, success, status, args, keepCallback));
 };
 
 // for backwards compatibility


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Fix the situation that Cordova native callbacks are not executed when the app is backgrounded of the Main UIView is not visible.

### What testing has been done on this change?
Testing of native callback functionality being executed.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
https://issues.apache.org/jira/browse/CB-12815
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
N/A IMO