### PR TITLE
GH-68 (ios): Support for disabling 3D Touch link previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ window.WkWebView.allowsBackForwardNavigationGestures(true)
 window.WkWebView.allowsBackForwardNavigationGestures(false)
 ```
 
+Disabling 3D Touch Link Previews
+-----------
+
+In order to disable preview popups when hard pressing links in iOS, you can set the following preference in your `config.xml`:
+
+```xml
+<preference name="Allow3DTouchLinkPreview" value="false" />
+```
+
 Limitations
 --------
 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -283,6 +283,7 @@ static void * KVOContext = &KVOContext;
     }
 
     wkWebView.allowsBackForwardNavigationGestures = [settings cordovaBoolSettingForKey:@"AllowBackForwardNavigationGestures" defaultValue:NO];
+    wkWebView.allowsLinkPreview = [settings cordovaBoolSettingForKey:@"Allow3DTouchLinkPreview" defaultValue:YES];
 }
 
 - (void)updateWithInfo:(NSDictionary*)info


### PR DESCRIPTION
### Platforms affected
- iOS

### What does this PR do?
- Adding support for a new preference - `Allow3DTouchLinkPreview` - if set to `false` disables link preview popups when 3D touching links in iOS.

Example usage in config.xml:
```
<preference name="Allow3DTouchLinkPreview" value="false" />
```



### What testing has been done on this change?
- Manually tested setting the preference to both true and false and omitting it.

### Checklist
- [ ] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [ ] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.

closes #68
