### PR TITLE
(ios) Bug fix in recent change in iOSExec.nativeCallback

### DIFF
--- a/src/www/ios/ios-wkwebview-exec.js
+++ b/src/www/ios/ios-wkwebview-exec.js
@@ -124,7 +124,9 @@ var iOSExec = function () {
 iOSExec.nativeCallback = function (callbackId, status, message, keepCallback, debug) {
     var success = status === 0 || status === 1;
     var args = convertMessageToArgsNativeToJs(message);
-    Promise.resolve(cordova.callbackFromNative(callbackId, success, status, args, keepCallback)); // eslint-disable-line
+    Promise.resolve().then(function () {
+        cordova.callbackFromNative(callbackId, success, status, args, keepCallback); // eslint-disable-line
+    });
 };
 
 // for backwards compatibility


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
Now, callbackFromNative will actually get called async. Before it was not.
See https://github.com/apache/cordova-plugin-wkwebview-engine/pull/49

### Description
Use resolve.then() exactly same as in https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/master/src/www/ios/ios-wkwebview-exec.js

### Testing
Works in an actual app

### Checklist
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)

