### PR TITLE
fix(ios): Avoid infinite loop on cancelled navigation

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -401,7 +401,9 @@ static void * KVOContext = &KVOContext;
     if (errorUrl) {
         errorUrl = [NSURL URLWithString:[NSString stringWithFormat:@"?error=%@", [message stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]] relativeToURL:errorUrl];
         NSLog(@"%@", [errorUrl absoluteString]);
-        [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+        if (error.code != NSURLErrorCancelled) {
+            [theWebView loadRequest:[NSURLRequest requestWithURL:errorUrl]];
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #83 
Ref https://github.com/apache/cordova-ios/pull/334

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Fixes #83


### Description
<!-- Describe your changes in detail -->
Similar as the fix in https://github.com/apache/cordova-ios/pull/334. It has the same symptoms.

The change is to not try to load the error URL in the event that didFailNavigation occurred in response to a cancelled navigation.


### Testing
<!-- Please describe in detail how you tested your changes. -->

The issue seems to be timing related. I found that it did not always replicate, depending on the device, and which server we were connecting to. As such, it is hard to produce an exact set of steps. But I found that for the servers against which we were always seeing the issue (100% replication), it no longer occurred.

### Checklist

- [ x ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ x ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))

