### PR TITLE
chore: drop Node.js v4 support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,17 +12,24 @@ image:
   - Visual Studio 2017
 
 environment:
-  nodejs_version: "4"
+  PLATFORM: windows-10-store
+  JUST_BUILD: --justBuild
   matrix:
-    - PLATFORM: windows-10-store
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+
+platform:
+  - x86
+  - x64
 
 install:
-  - npm cache clean -f
+  - ps: Install-Product node $env:nodejs_version
   - node --version
   - npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
   - npm install -g cordova
 
-build: off
+build: "off"
 
 test_script:
-  - cordova-paramedic --config pr\%PLATFORM% --plugin . --justBuild
+  - cordova-paramedic --config pr\%PLATFORM% --plugin . %JUST_BUILD%

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,34 @@
 sudo: false
+
 addons:
   jwt:
     secure: rjC2avwYWiw+oTHleXcJPlehTA2j0jRZj+UJHq7fRCJRYIsraKy2j9q3fOSjWR7MEvf+/hUwhmf4gFk2zrDukbc0x3rMdt47BwNtbpCTN05KbHebl5AH0xx0ZPkJ5N0tJqG2t4Bl9wqNRINOMES77Souduh4udQdtGfA9IBmhb0FPNHmW0J++essbNjd5b5MgitqgTi30x7Tvf9QYMmsTKpN8pdfbE29dgqiY/HTKbxyOU+X2Ed5mcMi/bGhSGU78JU3u91S0VA+w+bmNZIU4VeXEFbDkjIboPR41aIbsfHrk/41+k6BAcOurKJ1TxBNEVxL8ouZfAuPDWhJVABxdbtYAiem309nuUJ0fR05qtX9AO1mmMh+0xByyme2xjSjTvt6bzZLNm2EdS6dO5FmG8aBVX4JJCHkTM5wrA5MgRFbEcgfv5jp3ynvY7dNasfaOLFa+IxZ5qzPdzkXnTEwvwe7ioo5phMGbpefFrimDl/vy1QJdTTCUcvaXkqumQdJwaySYDq3Nsns10yDPEATI1NtZGHLbUM+W+ZOaoTZRKwRelLHF5oyOQnyIu2HzBfJS7pHlIbQaxtigWHuSWuee+sfmTPjj40y4uUqQAEDxmawKb6Y6xqQr+QpvI9pvpzeZYHdApNBe6mPDVh4hwgjlFhE3/iusnU+aeZHIUJEmME=
 env:
   global:
-  - SAUCE_USERNAME=snay
-  - TRAVIS_NODE_VERSION="4.2"
+    - SAUCE_USERNAME=snay
+    - TRAVIS_NODE_VERSION=6
+
+os: osx
+language: node_js
+node_js:
+  - "6"
+
 matrix:
   include:
-  - env: PLATFORM=ios-9.3 SHOULD_USE_SAUCE=--shouldUseSauce
-    os: osx
-    osx_image: xcode8
-    language: objective-c
-  - env: PLATFORM=ios-10.0 SHOULD_USE_SAUCE=--shouldUseSauce
-    os: osx
-    osx_image: xcode8
-    language: objective-c
-before_install:
-- rvm get head
-- npm cache clean -f
-- rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm
-  && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm
-  install $TRAVIS_NODE_VERSION
-- node --version
-- if [[ "$PLATFORM" =~ ios ]]; then xcodebuild -version; fi
-- if [[ "$PLATFORM" =~ ios ]]; then npm install -g ios-deploy; fi
-- git clone https://github.com/apache/cordova-paramedic /tmp/paramedic && pushd /tmp/paramedic
-  && npm install && popd
-- npm install -g cordova
-install:
-- npm install
-script:
-- if [[ "$PLATFORM" =~ ios ]]; then npm test; fi
-- node /tmp/paramedic/main.js --config pr/$PLATFORM --plugin $(pwd) $SHOULD_USE_SAUCE
-  --buildName travis-plugin-wkwebview-engine-$TRAVIS_JOB_NUMBER
+    - env: PLATFORM=ios-9.3 SHOULD_USE_SAUCE=--shouldUseSauce
+      osx_image: xcode8
+    - env: PLATFORM=ios-10.0 SHOULD_USE_SAUCE=--shouldUseSauce
+      osx_image: xcode8
 
-  
+before_install:
+- node --version
+- xcodebuild -version
+- npm install -g ios-deploy
+- npm install -g cordova-paramedic@https://github.com/apache/cordova-paramedic.git
+- npm install -g cordova
+
+install:
+  - npm install
+script:
+  - npm test
+  - cordova-paramedic --config pr/$PLATFORM --plugin $TRAVIS_BUILD_DIR --shouldUseSauce --buildName travis-$TRAVIS_REPO_SLUG-$TRAVIS_JOB_NUMBER


### PR DESCRIPTION
Part of apache/cordova#72

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

n/a - development

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Drops EOL Node.js 4 from CI config. BREAKING CHANGE! :)

### Description
<!-- Describe your changes in detail -->

see above.

### Testing
<!-- Please describe in detail how you tested your changes. -->

TravisCI and Appveyor test results.

### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
