### PR TITLE
ci(travis): add missing platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,10 @@ matrix:
     - env: ADDITIONAL_TESTS_DIR=./tests/ios
       <<: *_ios
 
+    # local tests, without saucelabs
+    - env: PLATFORM=local/ios-10.0
+      <<: *_ios
+
     # many tests with saucelabs
     - env: PLATFORM=ios-11.3
       <<: *_ios


### PR DESCRIPTION
The Travis configuration is currently missing some platforms because there are issues:

https://github.com/apache/cordova-plugin-wkwebview-engine/issues/101

When those are fixed, this can be merged to improve the coverage of the CI.