### PR TITLE
Revert "CB-13987: (ios) Fix WKWebView doesn't layout properly at launch on iPhoneX"

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -97,13 +97,6 @@
 
     // re-create WKWebView, since we need to update configuration
     WKWebView* wkWebView = [[WKWebView alloc] initWithFrame:self.engineWebView.frame configuration:configuration];
-
-#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000
-    if (@available(iOS 11.0, *)) {
-        [wkWebView.scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
-    }
-#endif
-    
     wkWebView.UIDelegate = self.uiDelegate;
     self.engineWebView = wkWebView;
 


### PR DESCRIPTION
Reverts apache/cordova-plugin-wkwebview-engine#45

This removes developer control over the handling of safe areas using the `viewport-fit` meta tag.

The **correct** way to fix unexpected gaps and layout issues lies at the HTML and CSS level:

* Set `viewport-fit=cover` directive in the `viewport` meta tag to make the webview contents extend into the safe area insets:

  ```html
  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
  ```

* If necessary, use `100vh` rather than `100%` to make your app container fill the screen:

  ```css
  body {
    min-height: 100vh;
  }
  ```

* Use CSS `env(safe-area-inset-*)` variables to add padding to avoid overlapping status bar text:

    ```css
    header {
      height: 44px;
      padding-top: env(safe-area-inset-top);
    }
    ```

closes #105