### PR TITLE
Remove traces of UIWebView API

### DIFF
--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -432,7 +432,7 @@ static void * KVOContext = &KVOContext;
             // https://issues.apache.org/jira/browse/CB-12497
             int navType = (int)navigationAction.navigationType;
             if (WKNavigationTypeOther == navigationAction.navigationType) {
-                navType = (int)UIWebViewNavigationTypeOther;
+                navType = 5; // UIWebViewNavigationTypeOther
             }
             shouldAllowRequest = (((BOOL (*)(id, SEL, id, int))objc_msgSend)(plugin, selector, navigationAction.request, navType));
             if (!shouldAllowRequest) {


### PR DESCRIPTION
As Apple seems to become very picky about the usage of UIWebView APIs, this PR removes the last trace of a UIWebView from this engine.
