### PR TITLE
Support custom scheme handling by WKURLSchemeHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ In order to disable preview popups when hard pressing links in iOS, you can set 
 <preference name="Allow3DTouchLinkPreview" value="false" />
 ```
 
+Custom Scheme Handling
+-----------
+
+In order to provide a custom way to load a custom url scheme, you can set the following preference in your `config.xml`:
+
+```xml
+<preference name="CustomURLSchemeHandler" value="{&quot;helloworld&quot;:&quot;MySchemeHandler&quot;}" />
+```
+
+The value is a JSON object that looks something like `{"scheme1": "MySchemeHandler1", "scheme2": "MySchemeHandler2"}`, object key is your scheme, value is your `WKURLSchemeHandler` subclass name. You can define multiple handlers in the object.
+
 Limitations
 --------
 

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -77,6 +77,24 @@
     configuration.mediaPlaybackRequiresUserAction = [settings cordovaBoolSettingForKey:@"MediaPlaybackRequiresUserAction" defaultValue:YES];
     configuration.suppressesIncrementalRendering = [settings cordovaBoolSettingForKey:@"SuppressesIncrementalRendering" defaultValue:NO];
     configuration.mediaPlaybackAllowsAirPlay = [settings cordovaBoolSettingForKey:@"MediaPlaybackAllowsAirPlay" defaultValue:YES];
+    
+    // support custom scheme handling by WKURLSchemeHandler
+    if (IsAtLeastiOSVersion(@"11.0")) {
+        NSString* handlerJsonString = [settings cordovaSettingForKey:@"CustomURLSchemeHandler"];
+        if (handlerJsonString != nil) {
+            NSError* error;
+            NSDictionary* handlerDic = [NSJSONSerialization JSONObjectWithData:[handlerJsonString dataUsingEncoding:NSUTF8StringEncoding] options:NSJSONReadingMutableContainers error:&error];
+            if(!error) {
+                for (NSString* scheme in handlerDic) {
+                    Class handlerCls = NSClassFromString(handlerDic[scheme]);
+                    if (handlerCls) {
+                        [configuration setURLSchemeHandler:[[handlerCls alloc] init] forURLScheme:scheme];
+                    }
+                }
+            }
+        }
+    }
+    
     return configuration;
 }
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
Support custom scheme handling for loading resources from custom folders.


### Description
In method `createConfigurationFromSettings`, the PR reads custom preference from `config.xml`, then sets all custom schemes and handlers by `setURLSchemeHandler`. The value of preference is a JSON object, it will be converted to dictionary after loading.



### Testing
I have tested it in my own cordova project by adding plugin from my own git repository. In my project custom `WKURLSchemeHandler` subclass redirects custom scheme requests to cordova library path.



### Checklist
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
