### PR TITLE
iOS: Fixes http cookie not stored properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ In order to disable preview popups when hard pressing links in iOS, you can set 
 <preference name="Allow3DTouchLinkPreview" value="false" />
 ```
 
+Fix HTTP cookies not saved (iOS >= 11 only)
+--------
+Initial cookie should be set using this command. After this cookie should be stored as expected.
+```js
+document.addEventListener('deviceready', () => {
+  wkWebView.injectCookie('mydomain.com/mypath');
+});
+```
+
 Limitations
 --------
 

--- a/src/ios/CDVWKWebViewEngine.h
+++ b/src/ios/CDVWKWebViewEngine.h
@@ -23,7 +23,9 @@
 @interface CDVWKWebViewEngine : CDVPlugin <CDVWebViewEngineProtocol, WKScriptMessageHandler, WKNavigationDelegate>
 
 @property (nonatomic, strong, readonly) id <WKUIDelegate> uiDelegate;
+@property (nonatomic, strong) NSString* callbackId;
 
 - (void)allowsBackForwardNavigationGestures:(CDVInvokedUrlCommand*)command;
+- (void)setCookie:(CDVInvokedUrlCommand *)command;
 
 @end

--- a/src/ios/CDVWKWebViewEngine.m
+++ b/src/ios/CDVWKWebViewEngine.m
@@ -471,6 +471,38 @@ static void * KVOContext = &KVOContext;
     wkWebView.allowsBackForwardNavigationGestures = [value boolValue];
 }
 
+- (void)setCookie:(CDVInvokedUrlCommand *)command {
+    self.callbackId = command.callbackId;
+
+    NSString *domain = command.arguments[0];
+    NSString *path = command.arguments[1];
+    NSString *name = command.arguments[2];
+    NSString *value = command.arguments[3];
+    
+    [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookieAcceptPolicy:NSHTTPCookieAcceptPolicyAlways];
+
+    WKWebView* wkWebView = (WKWebView*)_engineWebView;
+
+    if (@available(iOS 11.0, *)) {
+        NSMutableDictionary *cookieProperties = [NSMutableDictionary dictionary];
+        [cookieProperties setObject:name forKey:NSHTTPCookieName];
+        [cookieProperties setObject:value forKey:NSHTTPCookieValue];
+        [cookieProperties setObject:domain forKey:NSHTTPCookieDomain];
+        [cookieProperties setObject:domain forKey:NSHTTPCookieOriginURL];
+        [cookieProperties setObject:path forKey:NSHTTPCookiePath];
+        NSHTTPCookie * cookie = [NSHTTPCookie cookieWithProperties:cookieProperties];
+
+        [wkWebView.configuration.websiteDataStore.httpCookieStore setCookie:cookie completionHandler:^{NSLog(@"Cookies synced");}];
+        [[NSHTTPCookieStorage sharedHTTPCookieStorage] setCookie:cookie];
+
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    } else {
+        CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+    };
+}
+
 @end
 
 #pragma mark - CDVWKWeakScriptMessageHandler

--- a/src/www/ios/ios-wkwebview.js
+++ b/src/www/ios/ios-wkwebview.js
@@ -24,6 +24,18 @@ var exec = require('cordova/exec');
 var WkWebKit = {
     allowsBackForwardNavigationGestures: function (allow) {
         exec(null, null, 'CDVWKWebViewEngine', 'allowsBackForwardNavigationGestures', [allow]);
+    },
+    setCookie: function (url, name, value, successCallback, errorCallback) {
+        const urlNoDomain = url.replace(/^https?:\/\//, '');
+        const urlParts = urlNoDomain.split('/');
+        const domain = urlParts.splice(0,1)[0];
+        var path = urlParts.join('/');
+    
+        exec(successCallback, errorCallback, "CDVWKWebViewEngine",
+          "setCookie", [domain, path, name ? name : "foo", value ? value : "bar"]);
+    },
+    injectCookie: function (url, successCallback, errorCallback) {
+        this.setCookie(url, "foo", "bar", successCallback, errorCallback);
     }
 };
 


### PR DESCRIPTION
### Platforms affected
iOS

### Motivation and Context
closes #77 

### Description
Added ability to set initial cookie which solves the problem with setting HTTP cookies.
Based on https://github.com/CWBudde/cordova-plugin-wkwebview-inject-cookie

### Testing
Tested on Simulator iPhone 11 Pro Max

### Checklist
- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
