### PR TITLE
Added ios platform version restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In iOS 9, Apple has fixed the [issue](http://www.openradar.me/18039024) present 
 Installation
 -----------
 
-This plugin needs cordova-ios >4.0.0.
+This plugin needs cordova-ios 4.0.0 - 5.x. This plugin is not supported on cordova-ios >6.0.0.
 
 To install the current release:
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "engines": {
     "cordovaDependencies": {
       "2.0.0": {
-        "cordova": ">100"
+        "cordova": ">100",
+        "cordova-ios": "<6.0.0"
       }
     }
   },

--- a/plugin.xml
+++ b/plugin.xml
@@ -30,7 +30,7 @@
     <repo>https://github.com/apache/cordova-plugin-wkwebview-engine</repo>
 
 	<engines>
-        <engine name="cordova-ios" version=">=4.0.0-dev" />
+        <engine name="cordova-ios" version=">=4.0.0 <6.0.0" />
         <engine name="apple-ios" version=">=9.0" />
 	</engines>
 

--- a/tests/ios/package.json
+++ b/tests/ios/package.json
@@ -5,7 +5,7 @@
     "author": "Apache Software Foundation",
     "license": "Apache-2.0",
     "dependencies": {
-        "cordova-ios": "*"
+        "cordova-ios": "^5.1.1"
     },
     "scripts": {
         "test": "xcodebuild test -workspace CDVWKWebViewEngineTest.xcworkspace -scheme CDVWKWebViewEngineLibTests -destination 'platform=iOS Simulator,name=iPhone 5' -xcconfig test.xcconfig"


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
ios


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
This plugin is not supported on cordova-ios@6, therefore this PR adds a restraint for cordova-ios < 6

Closes https://github.com/apache/cordova-plugin-wkwebview-engine/issues/157 

### Description
<!-- Describe your changes in detail -->

Changed `package.json` and `plugin.xml` to restrict this plugin on `cordova-ios@6`.

### Testing
<!-- Please describe in detail how you tested your changes. -->
I ran `npm test`, but I could not run the native tests cause I don't have easy access to mac hardware. I'm relying on CI builds for native tests, and they have passed successfully.

I've tested using a project with the plugin installed, adding `cordova platform add ios@5.1.1` works as expected, `cordova platform add ios@6` produces:

```
Plugin doesn't support this project's cordova-ios version. cordova-ios: 6.0.0, failed version requirement: >=4.0.0 <6.0.0
Skipping 'cordova-plugin-wkwebview-engine' for ios
```

As expected.


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
