### PR TITLE
added WKWebViewOnly to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ WKWebView may not fully launch (the deviceready event may not fire) unless if th
 <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
 ```
 
-If using cordova-ios versions >= 5.1.0 you might also have to you might have to also include in order to only use the WKWebView (which is required for new Apps to the AppStore):
+If using cordova-ios versions >= 5.1.0 you might have to include the following tag in order to only use the WKWebView (which is required for new Apps to the AppStore):
 
 ```xml
 <preference name="WKWebViewOnly" value="true" />

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ WKWebView may not fully launch (the deviceready event may not fire) unless if th
 <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
 ```
 
+In order to only use the WKWebView (which is required for new Apps to the AppStore), you might have to also include 
+
+```xml
+<preference name="WKWebViewOnly" value="true" />
+```
+
 Notes
 ------
 This plugin creates a shared `WKProcessPool` which ensures the cookie sharing happens correctly across `WKWebView` instances. `CDVWKProcessPoolFactory` class can be used to obtain the shared `WKProcessPool` instance if app creates `WKWebView` outside of this plugin.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ WKWebView may not fully launch (the deviceready event may not fire) unless if th
 <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
 ```
 
-If using cordova-ios versions >= 5.1.0 you might have to include the following tag in order to only use the WKWebView (which is required for new Apps to the AppStore):
+If using `cordova-ios >= 5.1.0`, it is recommended to include the following `preference` tag to only use the `WKWebView` which is a requirement for new App submissions to the AppStore:
 
 ```xml
 <preference name="WKWebViewOnly" value="true" />

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ WKWebView may not fully launch (the deviceready event may not fire) unless if th
 <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
 ```
 
-In order to only use the WKWebView (which is required for new Apps to the AppStore), you might have to also include 
+If using cordova-ios versions >= 5.1.0 you might also have to you might have to also include in order to only use the WKWebView (which is required for new Apps to the AppStore):
 
 ```xml
 <preference name="WKWebViewOnly" value="true" />


### PR DESCRIPTION
added WKWebViewOnly to Readme to config Readme explanation.

### Motivation and Context

This is (afaik) needed in order to be able to upload new apps to the iOS App Store. I assume because without it both WebViews get delivered which then triggers Apples ITMS-90809: Deprecated API Usage Error on processing of the App


### Testing

try upload app to AppStoreConnect via XCode without the added xml tag and without.

with the tag:  ITMS-90809: Deprecated API Usage Error

with the tag: passes
