### PR TITLE
(ios) Add pref to accept untrusted certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ In order to disable preview popups when hard pressing links in iOS, you can set 
 <preference name="Allow3DTouchLinkPreview" value="false" />
 ```
 
+Allowing self-signed certificates
+-----------
+
+In order to allow access to HTTPS resources hosted on a webserver configured with a self-signed certificate, you can set the following preference in your `config.xml`:
+
+```xml
+<preference name="AllowUntrustedCerts" value="true" />
+```
+
 Limitations
 --------
 


### PR DESCRIPTION
### Platforms affected
iOS


### Motivation and Context
This change adds the ability to accept untrusted certificates (self-signed certificates for instance) thanks to a new preference in the `config.xml` file. It was needed because our development team test our mobile app along with a server instance hosted on their workstation, and this local instance uses self-signed certificates.



### Description
With this feature, you don't need to do anything on the device to be able to access web resources hosted on a server that uses self-signed certificates. To make a device accept or reject untrusted certificates, a new preference needs to be defined in the `config.xml` file (see README). Then, the corresponding Objective-C code controlled by the preference intercepts the HTTPS request right when iOS evaluates the certificate and dynamically adds an exception so that all certificates get accepted.



### Testing
This feature was tested with our mobile app. 
Setting the `AllowUntrustedCerts` preference to `true` for our debug builds allows us to access HTTPS resources hosted on a web server that uses self-signed certificates, setting it to false prevents us from doing so.



### Checklist

I have no prior Objective-C experience so I could use some help in case new tests are needed.
- [x] I've run the tests to see all existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] I've updated the documentation if necessary
